### PR TITLE
[ fix ] create a safety zone around resize corner

### DIFF
--- a/src/CyBy/Draw/Internal/Settings.idr
+++ b/src/CyBy/Draw/Internal/Settings.idr
@@ -34,6 +34,7 @@ record DrawSettings where
   maxZoom           : Scale
   minZoom           : Scale
   pseFontSize       : Nat
+  resizeCornerRad   : Double
 
 export
 defaultSettings : List Abbreviation -> DrawSettings
@@ -56,6 +57,7 @@ defaultSettings as =
    , maxZoom           = 20
    , minZoom           = 0.1
    , pseFontSize       = 11
+   , resizeCornerRad   = 20.0
    }
 
 export %inline %hint


### PR DESCRIPTION
This fixes #6 by creating a safety zone (default radius: 20px) around the lower right corner of the drawing canvas. The radius of the safety zone can be changed in the draw settings. Pressing the left mouse button hase no effect in the safety zone.

There might be much more elegant and less fragile solutions to this, but I currently don't have the capacity to look up how to figure out if we are hovering over the "resize" icon of an element or not.