### PR TITLE
[ fix ] less explosive templates

### DIFF
--- a/src/CyBy/Draw/MoleculeCanvas.idr
+++ b/src/CyBy/Draw/MoleculeCanvas.idr
@@ -529,14 +529,6 @@ onKeyUp "Control" s = {modifier $= reset Ctrl, mode $= stopTemplRot s} s
 onKeyUp "Meta"    s = {modifier $= reset Ctrl, mode $= stopTemplRot s} s
 onKeyUp _         s = s
 
-
-
-
-
-
-
-
-
 enableAbbr : DrawState -> DrawState
 enableAbbr s =
   case s.abbr of


### PR DESCRIPTION
This fixes #17: Templates are now less explosive and their abbreviations no longer expand all at once. Pity.