### PR TITLE
[ compat ] adjust to ubstream changes

### DIFF
--- a/src/CyBy/Draw.idr
+++ b/src/CyBy/Draw.idr
@@ -229,7 +229,7 @@ topBar {ds} pre s =
     , bondIcon "single-bond" (cast Single) "single bond" s
     , bondIcon "single-up" (fromStereo Up) "single bond up" s
     , bondIcon "single-down" (fromStereo Down) "single bond down" s
-    , bondIcon "single-up-down" (fromStereo UpOrDown) "single bond up or down" s
+    , bondIcon "single-up-down" (fromStereo Either) "single bond up or down" s
     , bondIcon "double-bond" (cast Dbl) "double bond" s
     , bondIcon "triple-bond" (cast Triple) "triple bond" s
     , icon "svg" SVG "svg"

--- a/src/CyBy/Draw/Draw.idr
+++ b/src/CyBy/Draw/Draw.idr
@@ -272,10 +272,10 @@ parameters {auto s : DrawSettings}
           Hidden     => ns2
 
   snglBond : Maybe SVGColor -> Point Id -> Point Id -> BondStereo -> TNodes
-  snglBond c x y Up       ns = wedgeUp x y $ wedgeBG c x y ns
-  snglBond c x y UpOrDown ns = wave x y $ waveBG c x y ns
-  snglBond c x y Down     ns = wedgeDown x y $ wedgeBG c x y ns
-  snglBond c x y _        ns = line x y $ lineBG c x y ns
+  snglBond c x y Up     ns = wedgeUp x y $ wedgeBG c x y ns
+  snglBond c x y Either ns = wave x y $ waveBG c x y ns
+  snglBond c x y Down   ns = wedgeDown x y $ wedgeBG c x y ns
+  snglBond c x y _      ns = line x y $ lineBG c x y ns
 
   dblBond : Maybe SVGColor -> Fin k -> Fin k -> Point Id -> Point Id -> TNodes
   dblBond c x y px py ns =

--- a/src/CyBy/Draw/Internal/Label.idr
+++ b/src/CyBy/Draw/Internal/Label.idr
@@ -55,7 +55,7 @@ export
 t.w = t.dims.txtWidth
 
 public export
-Bounded (Text $ Point Id) where
+Geom.Bounds.Bounded (Text $ Point Id) where
   btrans = Id
   bounds (T _ "" _ _) = neutral
   bounds (T _ _ (P x y) (TD _ cs w)) =
@@ -121,7 +121,7 @@ labels : AtomLabels a -> List (Text a)
 labels (AL v w x y z) = [v,w,x,y,z]
 
 public export
-Bounded (AtomLabels $ Point Id) where
+Geom.Bounds.Bounded (AtomLabels $ Point Id) where
   btrans = Id
   bounds = foldMap bounds . labels
 
@@ -279,7 +279,7 @@ circleBounds (P x y) =
   let r := cd.radiusAtom in BS (range (x-r) (x+r)) (range (y-r)(y+r))
 
 public export
-(cd : CoreDims) => Bounded Label where
+(cd : CoreDims) => Geom.Bounds.Bounded Label where
   btrans = Id
   bounds Hidden             = neutral
   bounds (NoLabel p)        = circleBounds p

--- a/src/CyBy/Draw/MoleculeCanvas.idr
+++ b/src/CyBy/Draw/MoleculeCanvas.idr
@@ -83,7 +83,7 @@ hoverAtom _            _ = False
 
 hoverDrawing : MolBond -> MolBond -> Bool -> Bool
 hoverDrawing (MkBond _ Single NoBondStereo) _ a = not a
-hoverDrawing (MkBond _ Single UpOrDown)     b _ = b.stereo /= UpOrDown
+hoverDrawing (MkBond _ Single Either)       b _ = b.stereo /= Either
 hoverDrawing (MkBond _ Single _)            _ _ = True
 hoverDrawing (MkBond _ x      _)            b a = not a && b.type /= x
 


### PR DESCRIPTION
Support for .mol file format V3000 has been added to idris2-chem with some minor breaking changes. This PR adjusts cyby-draw to those changes.

For the time being, we are going to keep using version 2000 when copying molecules to the clipboard. However, reading *from* the clipboard will now also work with the newer format. In addition, this removes the size and order limits of our molecular graphs. With the next idris2-chem PR, large molecules with more than 999 bonds or atoms will be automatically written as V3000.