### PR TITLE
[ doc,cleanup ] documenting load function and remove redundant load and sync

### DIFF
--- a/word-addin/src/CyBy/Draw/Word.idr
+++ b/word-addin/src/CyBy/Draw/Word.idr
@@ -124,8 +124,6 @@ exportImage svg mol =
     -- therefore not all structures have the same length!)
     -- maybe change to appending the image to the end of the file
     tempImg <- insertInlinePictureFromB64 s svgTemp
-    load c tempImg "" -- TODO: what does this do?
-    syncContext c
 
     tempOoxml <- getOoxml c
 

--- a/word-addin/src/CyBy/Draw/Word/DomBindings.idr
+++ b/word-addin/src/CyBy/Draw/Word/DomBindings.idr
@@ -174,10 +174,10 @@ export
 syncContext : Context -> Prog ()
 syncContext c = liftPrimPromise (prim__syncContext c)
 
-||| Takes an JS object and a comma-delimited string of properties for loading
-||| this properties for later use.
-|||
-||| TODO: What does this mean? What kind of properties are these?
+|||  Queuing a request to fetch data for a proxy object, which initially
+|||  contains no real values. `load("")` requests all properties.
+|||  `context.sync()` is required afterward to retrieve the data and make it
+|||  accessible!
 export
 load : Context -> a -> (properties : String) -> Prog ()
 load c o props = primIO (prim__load o props) >> syncContext c
@@ -203,8 +203,8 @@ export
 getSelection : Context -> Prog Selection
 getSelection c = do
   s <- primIO (prim__selection c)
-  load c s "isEmpty" -- TODO: what does this do?
-  syncContext c      -- TODO: why do we need to sync the context before returning?
+  load c s "isEmpty"
+  syncContext c
   pure s
 
 export


### PR DESCRIPTION
This little PR adds a better description of the word js api 'load()' function and removes one unnecessary use of it.