### PR TITLE
[ export ] safe current molecule to file

### DIFF
--- a/pack.toml
+++ b/pack.toml
@@ -13,6 +13,12 @@ type    = "local"
 path    = "word-addin"
 ipkg    = "cyby-draw-word-addin.ipkg"
 
+[custom.all.async-dom]
+type   = "git"
+url    = "https://github.com/stefan-hoeck/idris2-async-dom"
+commit = "latest:main"
+ipkg   = "async-dom.ipkg"
+
 [custom.all.ref1]
 type   = "git"
 url    = "https://github.com/stefan-hoeck/idris2-ref1"

--- a/src/CyBy/Draw.idr
+++ b/src/CyBy/Draw.idr
@@ -41,6 +41,12 @@ fromClipboard =
         Right m => sink (Event.SetTempl $ initGraph m.graph)
       Right g => sink (Event.SetTempl g)
 
+%foreign "browser:lambda:(s,w)=> {const blob = new Blob([s], { type: 'image/svg+xml' }); const url = URL.createObjectURL(blob); const a = document.createElement('a'); a.href = url; a.download = 'cyby_draw_img.svg'; a.click(); URL.revokeObjectURL(url);}"
+prim__downloadSVG : String -> PrimIO ()
+
+downloadSVG : HasIO io => String -> io ()
+downloadSVG s = primIO (prim__downloadSVG s)
+
 --------------------------------------------------------------------------------
 -- Extensions
 --------------------------------------------------------------------------------
@@ -538,6 +544,6 @@ export %hint
 NoExt : Extension
 NoExt =
   E
-    { doExport     = toClipboard . exportSVG
+    { doExport     = downloadSVG . exportSVG
     , buttons      = \pre => [ icon' [Id $ expButton pre] "svg" SVG "svg" ]
     }

--- a/src/CyBy/Draw/MoleculeCanvas.idr
+++ b/src/CyBy/Draw/MoleculeCanvas.idr
@@ -774,4 +774,4 @@ parameters {auto ds : DrawSettings}
   ||| field value.
   export
   exportSVG : DrawState -> String
-  exportSVG = snd . exportSVGPair False ""
+  exportSVG = snd . exportSVGPair True ""


### PR DESCRIPTION
Today, I did some research about how to best export our images and load them into other applications. Due to security reasons, writing them to the clipboard with an `image/svg` mime type is prohibited by most browsers. Same for loading them from the clipboard with such a mime type.

The most portable way is to therefore "download" and store the SVG image and drag and drop (or import) that downloaded file into the word editor of our choice.

With this PR, this is what's now happening when clicking the "SVG" button.

And yes, the FFI code is horrible. I'll clean it up later. Schwör.