### PR TITLE
[ new ] set colour scheme at cyby-draw-app

### DIFF
--- a/app/src/Html.idr
+++ b/app/src/Html.idr
@@ -1,9 +1,11 @@
 module Html
 
 import CyBy.Draw
+import Data.Finite
 import Data.List
 import Text.CSS.Color
 import Text.HTML.DomID
+import Text.HTML.Select
 import Text.Molfile
 import Text.SVG
 import Web.Async.Util
@@ -45,19 +47,72 @@ parameters {auto lg : Logger JS}
     logLoggable Copied      = info "Structure copied to clipboard"
     logLoggable (ReadErr s) = error "Error when pasting structure: \{s}"
 
-  logAndDisplay : DrawSettings => Sink DrawEvent => DrawEvent -> DrawState -> Act DrawState
-  logAndDisplay e s =
-   let s2 := update e s
-    in displaySketcher "app" e s2 $> s2
+--------------------------------------------------------------------------------
+-- App
+--------------------------------------------------------------------------------
 
-ui : DrawSettings => JSStream Void
-ui = do
+data AppEvent : Type where
+  SetColor : ColorScheme -> AppEvent
+
+record AppST where
+  constructor AST
+  scheme : ColorScheme
+
+drawSettings : AppST -> DrawSettings
+drawSettings (AST s) = {elemColor := color s} (defaultSettings abbreviations)
+
+parameters {auto st  : IORef AppST}
+           {auto sde : Sink DrawEvent}
+           {auto sdm : Sink DrawMsg}
+           {auto sae : Sink AppEvent}
+           {auto lg  : Logger JS}
+           (ast      : IORef AppST)
+           (dst      : IORef DrawState)
+
+  btns : DrawEnv -> DrawState -> Act HTMLNodes
+  btns _ s = Prelude.do
+    AST c <- readref ast 
+    pure
+      [ expBtn "svg" "store image" s
+      , selectFromList values (Just c) show SetColor [class "color-scheme"]
+      ]
+
+  ext : Extension
+  ext =
+    E
+      { doExport = storeSVG . exportSVG
+      , buttons  = btns
+      , adjust   = \_,_,s => disableExport s
+      }
+
+  drawEv : DrawState -> DrawEvent -> Act DrawState
+  drawEv s e = Prelude.do
+    ds <- drawSettings <$> readref ast
+    let s2 := update e s
+    displaySketcher {ex = ext} "app" e s2
+    pure s2
+
+  appEv : AppEvent -> Act ()
+  appEv (SetColor x) = mod ast {scheme := x} >> sink Redraw
+
+ui : JSStream Void
+ui = Prelude.do
   let lg := uilog Info
-  E des <- exec $ eventFrom (KeyDown "Escape")
+  E dms <- exec $ event {fs = [JSErr]} DrawMsg
+  E aes <- exec $ event {fs = [JSErr]} AppEvent
+  E des <- exec $ eventFrom {fs = [JSErr]} (KeyDown "Escape")
   r     <- exec $ castElementByRef Content >>= getClientRect
-  let dims := SD (cast $ r.width - 350) (cast $ r.height - 100)
-  mvcActEvs des (init dims Init "") logAndDisplay
+  ast   <- newref (AST CyBy)
+  let ds   := drawSettings (AST CyBy)
+      dims := SD (cast $ r.width - 350) (cast $ r.height - 100)
+      st   := init dims Init ""
+  dst   <- newref {s = World} st
+  merge
+    [ foreach logLoggable dms
+    , foreach (appEv ast dst) aes
+    , P.evalScans1 st (drawEv ast dst) des |> foreach (writeref dst)
+    ]
 
 export covering
 app : IO ()
-app = runProg $ ui @{defaultSettings abbreviations}
+app = runProg ui

--- a/src/CyBy/Draw.idr
+++ b/src/CyBy/Draw.idr
@@ -11,6 +11,7 @@ import Text.SVG
 import Web.Async
 import Web.Internal.Types
 
+import CyBy.Draw.Internal.Color
 import CyBy.Draw.Internal.Label
 import Geom.Gen2D.Debug
 
@@ -29,6 +30,16 @@ import public Text.Molfile
 
 %default total
 
+export
+color : ColorScheme -> Elem -> SVGColor
+color Black  = const black
+color CyBy   = basicColors
+color Groups = groupColors
+color CPK    = cpkColor
+color CDK    = cdkColor
+color JMol   = jmolColor
+color PyMol  = pymolColor
+
 %inline
 molToClipboard : HasIO io => CDGraph -> io ()
 molToClipboard = toClipboard . writeMolfile . toMolfile
@@ -42,13 +53,14 @@ fromClipboard =
         Right m => sink (Event.SetTempl $ initGraph m.graph)
       Right g => sink (Event.SetTempl g)
 
-downloadSVG : String -> Act ()
-downloadSVG s =
+export
+storeSVG : String -> Act ()
+storeSVG s =
   use1 (blob s "image/svg+xml" >>= blobURL) $ \u => Prelude.do
     e  <- createElement "a"
     setAttribute e "href" (cast u)
     setAttribute e "download" "cyby_draw_img.svg"
-    he <- jsCast {t = HTMLElement} "downloadSVG:<a> conversion" e
+    he <- jsCast {t = HTMLElement} "storeSVG:<a> conversion" e
     click he
 
 --------------------------------------------------------------------------------
@@ -402,6 +414,7 @@ parameters {auto de : Sink DrawEvent}
         ]
       ]
 
+export
 expBtn : DrawEnv => Class -> (title : String) -> DrawState -> HTMLNode
 expBtn @{DE pre} c t s =
   icon' [Id $ expButton pre, disabled $ emptyGraph s] c SVG t
@@ -446,9 +459,9 @@ parameters {auto ds : DrawSettings}
   focusCurrentApp : Act ()
   focusCurrentApp = focus (moleculeCanvas pre)
 
-  displayST : DrawState -> Act ()
-  displayST s =
-    when (s.curSVG /= s.prevSVG) $
+  displayST : (force : Bool) -> DrawState -> Act ()
+  displayST force s =
+    when (force || s.curSVG /= s.prevSVG) $
       child (moleculeCanvas pre) (Raw s.curSVG) >>
       when s.hasFocus focusCurrentApp
 
@@ -509,12 +522,14 @@ parameters {auto ds : DrawSettings}
   displayEv (ZoomOut _)      s = adjustBars s
   displayEv Clear            s = adjustBars s
   displayEv SVG              s = ex.doExport s
+  displayEv Redraw           s = displayST True s
   displayEv _                s = pure ()
 
 
   export
   displaySketcher : DrawEvent -> DrawState -> Act ()
-  displaySketcher e s = displayEv e s >> displayST s >> ex.adjust (DE pre) e s
+  displaySketcher e s =
+    displayEv e s >> displayST False s >> ex.adjust (DE pre) e s
 
 export
 disableExport : DrawEnv => DrawState -> Act ()
@@ -572,7 +587,7 @@ export %hint
 NoExt : Extension
 NoExt =
   E
-    { doExport = downloadSVG . exportSVG
+    { doExport = storeSVG . exportSVG
     , buttons  = \_,s => pure [expBtn "svg" "store image" s]
     , adjust   = \_,_,s => disableExport s
     }

--- a/src/CyBy/Draw/Event.idr
+++ b/src/CyBy/Draw/Event.idr
@@ -3,12 +3,25 @@ module CyBy.Draw.Event
 import CyBy.Draw.Internal.Abbreviations
 import CyBy.Draw.Internal.Atom
 import CyBy.Draw.Internal.Graph
+import Derive.Finite
+import Derive.FromJSON.Simple
+import Derive.ToJSON.Simple
 import Derive.Prelude
+import JSON.Simple
 import Text.Molfile
 import Web.Canvas
 
 %default total
 %language ElabReflection
+
+--------------------------------------------------------------------------------
+-- Color Schemes
+--------------------------------------------------------------------------------
+
+public export
+data ColorScheme = Black | CyBy | Groups | CPK | CDK | JMol | PyMol
+
+%runElab derive "ColorScheme" [Show,Eq,Ord,Finite,FromJSON,ToJSON]
 
 --------------------------------------------------------------------------------
 --          Event
@@ -70,6 +83,7 @@ data DrawEvent : Type where
   Clear            : DrawEvent
   Expand           : DrawEvent
   Center           : DrawEvent
+  Redraw           : DrawEvent
   Resize           : (h,w : Double) -> DrawEvent
   StartPSE         : DrawEvent
   SVG              : DrawEvent

--- a/src/CyBy/Draw/MoleculeCanvas.idr
+++ b/src/CyBy/Draw/MoleculeCanvas.idr
@@ -678,6 +678,7 @@ upd (Resize h w)  s = endResize h w s
 upd StartPSE      s = {mode := PTable Nothing} s
 upd SVG           s = s
 upd SVGimp        s = s
+upd Redraw        s = s
 
 ||| Convert an `AffineTransformation` to a transformation to be
 ||| used in an SVG element.


### PR DESCRIPTION
This is the next step towards #88. It converts the example application to a proper, free standing tool with its own event stream that runs concurrently to the default one from cyby-draw. It also allows us to change the colour scheme (same schemes available as in CyBy) and thus export molecules all in black as is often expected in documents.

Note: The word-addin will be adjusted in a separate PR.