### PR TITLE
[ fix ] use Load event for loading molecules from files

### DIFF
--- a/app/src/Html.idr
+++ b/app/src/Html.idr
@@ -118,17 +118,17 @@ parameters {auto st  : IORef AppST}
       _:<"mol" =>
         case readMolfileE (cast bs) of
           Left x  => logLoggable (ReadErr x)
-          Right g => sink (Event.SetTempl g)
+          Right g => sink (Event.Load g)
       _:<"smi" =>
         case smilesToMol (cast bs) of
           Left x  => logLoggable (ReadErr x)
-          Right m => sink (Event.SetTempl $ initGraph m.graph)
+          Right m => sink (Event.Load $ initGraph m.graph)
       _:<"svg" =>
         case between "<metadata>" "</metadata>" (cast bs) of
           Nothing  => logLoggable (ReadErr ".svg file does not contain required metadata")
           Just bs2 => case readMolfileE (toString bs2) of
             Left x  => logLoggable (ReadErr x)
-            Right g => sink (Event.SetTempl g)
+            Right g => sink (Event.Load g)
       _ => logLoggable (ReadErr "unsupported file type")
 
   appEv : AppEvent -> Act ()


### PR DESCRIPTION
This makes use of Claudio's `Load` event (instead of `SetTempl`) for loading molecules from files. With large molecules, `SetTempl` has the disadvantage that immediately after placing the molecule, a new one can be placed, which leads to a collision detection being run (`O(n^2)`!), which can lead to a dramatic slowdown.

Using `Load` allows us to import quite large data sets: For instance, it is perfectly feasible to import an excerpt of 500 molecules from the zinc database, generate coordinates for them, and arrange them in a grid (to do this, the molecules need to be loaded as a single, disconnected graph, so they must be separated by dots, not by line breaks).