### PR TITLE
[ css ] more semantics

### DIFF
--- a/app/src/Html.idr
+++ b/app/src/Html.idr
@@ -131,7 +131,7 @@ ui = Prelude.do
   dst    <- newref {s = World} st
   topadd <- exec (buttons (ext ast dst) (DE App) st)
   exec $ child Content (sketcher App topadd st)
-  exec $ append (rightBarID App) appLog
+  exec $ append (infoID App) appLog
   merge
     [ foreach logLoggable dms
     , foreach (appEv ast dst) aes

--- a/cyby-css/src/CyBy/UI/CSS/Classes.idr
+++ b/cyby-css/src/CyBy/UI/CSS/Classes.idr
@@ -25,14 +25,6 @@ invalid = Bool "data-invalid"
 --------------------------------------------------------------------------------
 
 export %inline
-quadratic : Class
-quadratic = "cyby-quadratic"
-
-export %inline
-smallText : Class
-smallText = "cyby-small-text"
-
-export %inline
 formsep : Class
 formsep = "cyby-form-sep"
 
@@ -49,24 +41,24 @@ vbarsep = "cyby-vbar-sep"
 --------------------------------------------------------------------------------
 
 export %inline
-sketcherDiv : Class
-sketcherDiv = "cyby-draw-sketcher-div"
+sketcher : Class
+sketcher = "cyby-draw-sketcher"
 
 export %inline
-toolbarTop : Class
-toolbarTop = "cyby-draw-toolbar-top"
+drawUtils : Class
+drawUtils = "cyby-draw-utils"
 
 export %inline
-toolbarLeft : Class
-toolbarLeft = "cyby-draw-toolbar-left"
+drawElems : Class
+drawElems = "cyby-draw-elems"
 
 export %inline
-toolbarRight : Class
-toolbarRight = "cyby-draw-toolbar-right"
+drawInfo : Class
+drawInfo = "cyby-draw-info"
 
 export %inline
-toolbarBottom : Class
-toolbarBottom = "cyby-draw-toolbar-bottom"
+drawTemplates : Class
+drawTemplates = "cyby-draw-templates"
 
 export %inline
 drawDetails : Class
@@ -75,14 +67,6 @@ drawDetails = "cyby-draw-details"
 export %inline
 drawLog : Class
 drawLog = "cyby-draw-log"
-
-export %inline
-compList : Class
-compList = "cyby-comp-list"
-
-export %inline
-compTitle : Class
-compTitle = "cyby-comp-title"
 
 export %inline
 moleculeCanvas : Class
@@ -97,16 +81,12 @@ dragging : Class
 dragging = "cyby-draw-dragging"
 
 export %inline
-formRow : Class
-formRow = "cyby-form-row"
+listEntry : Class
+listEntry = "cyby-list-entry"
 
 export %inline
-formLabel : Class
-formLabel = "cyby-form-label"
-
-export %inline
-formValue : Class
-formValue = "cyby-form-value"
+listEntryValue : Class
+listEntryValue = "cyby-list-entry-value"
 
 export
 level : LogLevel -> Class

--- a/cyby-css/src/CyBy/UI/CSS/Rules.idr
+++ b/cyby-css/src/CyBy/UI/CSS/Rules.idr
@@ -13,15 +13,7 @@ import Text.HTML.Tag
 %default total
 %language ElabReflection
 
-public export
-0 Rules0 : Type
-Rules0 = List (Rule 0)
-
-public export
-0 Rules : Type
-Rules = List (Rule 1)
-
-data Tag = Top | Bot | Left | Details | Draw | Dot
+data Tag = Util | Templates | Elems | Info | Draw | Dot
 
 %runElab derive "Tag" [Show,Eq]
 
@@ -50,14 +42,19 @@ parameters {auto v : Vars}
   padded : Declaration
   padded = padding (All v.paddingH)
 
+  ||| Flex container with a default gap between components that
+  ||| arranges components horizontally.
   export
   flexRow : List Declaration
   flexRow = [display Flex, flexDirection Row, columnGap v.gap]
 
+  ||| Flex container with a default gap between components that
+  ||| arranges components vertically.
   export
   flexColumn : List Declaration
   flexColumn = [display Flex, flexDirection Column, rowGap v.gap]
 
+  ||| Solid, narrow border of the given color.
   export
   solidBorder : Color -> List Declaration
   solidBorder c =
@@ -66,10 +63,12 @@ parameters {auto v : Vars}
     , borderColor (All c)
     ]
 
+  ||| `solidBorder` with rounded corners using the default corner radius.
   export
   roundedBorder : Color -> List Declaration
   roundedBorder c = borderRadius v.cornerRad :: solidBorder c
 
+  ||| Regular widget with default colors for font, background, and border.
   export
   wregular : List Declaration
   wregular =
@@ -79,6 +78,8 @@ parameters {auto v : Vars}
     :: outlineStyle None
     :: roundedBorder Current
 
+  ||| Widget that has either the `data-active` attribute set, or
+  ||| is in an `active` state (has the `:active` pseudoclass).
   export
   wactive : List Declaration
   wactive =
@@ -88,6 +89,7 @@ parameters {auto v : Vars}
     , outlineWidth v.narrowBW
     ]
 
+  ||| Widget that is being hovered over (has the `:hover` pseudoclass).
   export
   whovered : List Declaration
   whovered =
@@ -97,6 +99,7 @@ parameters {auto v : Vars}
     , outlineWidth v.narrowBW
     ]
 
+  ||| Disabled widget (has the `:disabled` pseudoclass).
   export
   wdisabled : List Declaration
   wdisabled =
@@ -105,6 +108,7 @@ parameters {auto v : Vars}
     :: outlineStyle None
     :: roundedBorder disabledBG
 
+  ||| Outline and border of a cyby-draw component.
   export
   drawCompBorder : List Declaration
   drawCompBorder =
@@ -112,6 +116,22 @@ parameters {auto v : Vars}
     :: outlineWidth v.narrowBW
     :: outlineColor v.gray80
     :: roundedBorder bg
+
+  drawTitle : List Declaration
+  drawTitle =
+       width 100.perc
+    :: display Flex
+    :: alignItems Center
+    :: height v.titleHeight
+    :: backgroundColor widgetFG
+    :: color v.primary10
+    :: hpadded
+    :: margin 0.px
+    :: fontSize 1.em
+    :: roundedBorder widgetFG
+
+  drawList : List Declaration
+  drawList = flex "1" :: overflowY Scroll :: padded :: flexColumn
 
 --------------------------------------------------------------------------------
 -- General
@@ -132,18 +152,12 @@ parameters {auto v : Vars}
         , padding 1.em
         , containerType Size
         ]
-  
+
     -- this makes sure that the text in a label is vertically centered
     , elem Label [display Flex , alignItems Center]
-  
-    , sel {n = 1} (set hidden) [display None]
-  
-    , class quadratic [aspectRatio 1]
-  
-    , class smallText [fontSize Small]
 
     , class hbarsep [backgroundColor bar, width 100.perc, height v.barSepwidth]
-
+ 
     , class vbarsep [backgroundColor bar, height 100.perc, width v.barSepwidth]
 
     , class formsep [backgroundColor bar, width 100.perc, height v.formSepwidth]
@@ -153,63 +167,62 @@ parameters {auto v : Vars}
   export
   components : Rules
   components =
-    [ class sketcherDiv $
+    [ class sketcher $
         area
           [cast v.bardim, 1.fr, cast v.bardim]
           [cast v.bardim, 4.fr, 1.fr]
-          [ [Dot,  Top,  Top]
-          , [Left, Draw, Details]
-          , [Dot,  Bot,  Bot]
+          [ [Dot,   Util,      Util     ]
+          , [Elems, Draw,      Info     ]
+          , [Dot,   Templates, Templates]
           ]
         :: width 100.perc
         :: height 100.perc
         :: gridGaps
 
-    , Container "width < 1440px" [class sketcherDiv [fontSize v.smallFont]]
-    , Container "width < 1024px" [class sketcherDiv [fontSize v.xsmallFont]]
-    , Container "width < 768px"  [class sketcherDiv [fontSize v.xxsmallFont]]
-  
-    , class toolbarTop    $ gridArea Rules.Top   :: flexRow
-    , class toolbarBottom $ gridArea Rules.Bot   :: flexRow
-    , class toolbarLeft   $ gridArea Rules.Left  :: flexColumn
-    , class toolbarRight  $
-           [containerType Size, gridArea Rules.Details]
-        ++ flexColumn
-        ++ drawCompBorder
+    -- the following rules make for a responsive design:
+    -- by reducing the font size of the sketcher, the dimensions of
+    -- all other components as well as paddings and corners are
+    -- adjusted as well.
+    , Container "width < 1440px" [class sketcher [fontSize v.smallFont]]
+    , Container "width < 1024px" [class sketcher [fontSize v.xsmallFont]]
+    , Container "width < 768px"  [class sketcher [fontSize v.xxsmallFont]]
 
-    , class drawDetails $
-        [containerType Size, flex "2"] ++ flexColumn ++ drawCompBorder
-
-    , class drawLog $
-           [fontSize v.smallFont, containerType Size, flex "1"]
-        ++ flexColumn
-        ++ drawCompBorder
-
-    , class compList $ flex "1" :: overflowY Scroll :: padded :: flexColumn
-
-    , class compTitle $
-           width 100.perc
-        :: display Flex
-        :: alignItems Center
-        :: height v.titleHeight
-        :: backgroundColor widgetFG
-        :: color v.primary10
-        :: hpadded
-        :: roundedBorder widgetFG
-  
+    -- the drawing canvas
     , class moleculeCanvas $
            width 100.perc
         :: height 100.perc
-        :: minWidth 0.px
-        :: minHeight 0.px
+        :: minWidth 0.px    -- necessary to resize this when parent is resized
+        :: minHeight 0.px   -- necessary to resize this when parent is resized
         :: gridArea Draw
         :: drawCompBorder
-  
+
+    -- drawing canvas: special states
     , sel [class moleculeCanvas, set active]
         [backgroundColor white, outlineWidth v.fatBW, outlineColor activeFG]
     , classes [moleculeCanvas,dragging] [cursor [Move]]
     , classes [moleculeCanvas,rotating]
         [cursor [URL_ "data:image/png;base64,\{rotate}", Cursor.Auto]]
+
+    -- CyBy Draw toolbars
+    , class drawUtils $ gridArea Util :: flexRow
+    , class drawTemplates $ gridArea Templates :: flexRow
+    , class drawElems $ gridArea Elems :: flexColumn
+    , class drawInfo $ [containerType Size, gridArea Rules.Info] ++ flexColumn
+
+    -- CyBy Draw details
+    , class drawDetails $
+        [containerType Size, flex "2"] ++ flexColumn ++ drawCompBorder
+    , sel (class drawDetails > elem H1) drawTitle
+    , sel (class drawDetails > elem Ul) drawList
+
+    -- logging
+    , class drawLog $
+           [fontSize v.smallFont, containerType Size, flex "1"]
+        ++ flexColumn
+        ++ drawCompBorder
+
+    , sel (class drawLog > elem H1) drawTitle
+    , sel (class drawLog > elem Ul) drawList
 
     , class (level Fatal) [color red]
     , class (level Error) [color red]
@@ -223,16 +236,17 @@ parameters {auto v : Vars}
   export
   forms : Rules
   forms =
-    [ class formRow $ alignItems Stretch :: flexRow
-    , class formLabel [width v.formLblWidth]
-    , class formValue [flex "1"]
+    [ class listEntry $ alignItems Stretch :: flexRow
+    , sel (class listEntry > elem Label) [width v.formLblWidth]
+    , Sel [class listEntryValue, class listEntry > class widget] [flex "1"]
     , Container "width < 300px"
-        [class formRow $ alignItems Start :: flexColumn
-        ,class formLabel [width 100.perc]
-        ,class formValue [flex "0 0 auto", margin (Left v.gap)]
+        [ class listEntry $ alignItems Start :: flexColumn
+        , sel (class listEntry > elem Label) [width 100.perc]
+        , Sel [class listEntryValue, class listEntry > class widget]
+            [flex "0 0 auto", margin (Left v.gap)]
         ]
     ]
-  
+
   ||| Rules for interactive UI elements
   export
   widgets : Rules
@@ -243,7 +257,7 @@ parameters {auto v : Vars}
     , sel [Class widget, set active] wactive
     , sel [Class widget, Disabled] wdisabled
   
-    , classes [widget, icon] [padding 0.px]
+    , classes [widget, icon] [padding 0.px, aspectRatio 1]
   
     , class (elemText B)  [fontWeight Bold, color v.boron]
     , class (elemText C)  [fontWeight Bold, color v.carbon]

--- a/cyby-css/src/CyBy/UI/HTML.idr
+++ b/cyby-css/src/CyBy/UI/HTML.idr
@@ -36,19 +36,14 @@ CyByLog = "cyby-log"
 export
 logNode : LogLevel -> List String -> HTMLNode
 logNode l msgs =
-  div [class formRow]
-    [ div [classes [formLabel, level l]] [Text $ "[\{l}]"]
-    , div [class formValue] $ intersperse (br []) (map Text msgs)
+  li [class listEntry]
+    [ div [class $ level l] [Text $ "[\{l}]"]
+    , div [class listEntryValue] $ intersperse (br []) (map Text msgs)
     ]
 
 export
 appLog : HTMLNode
-appLog =
-  div
-    [ class drawLog ]
-    [ div [class compTitle] ["Log"]
-    , div [ref CyByLog, classes [compList]] []
-    ]
+appLog = div [class drawLog] [h1 [] ["Log"], ul [ref CyByLog] []]
 
 --------------------------------------------------------------------------------
 -- Icons

--- a/src/CyBy/Draw.idr
+++ b/src/CyBy/Draw.idr
@@ -131,41 +131,27 @@ wheel wi =
 --          IDs
 --------------------------------------------------------------------------------
 
-export
 moleculeCanvas : String -> Ref Div
 moleculeCanvas pre = Id "\{pre}-molecule-canvas"
 
-export
 sketcherDiv : String -> Ref Div
 sketcherDiv pre = Id "\{pre}-sketcher-div"
 
-export
-molReader : String -> Ref Div
-molReader pre = Id "\{pre}-mol-reader"
+elemsID : String -> Ref Div
+elemsID pre = Id "\{pre}-elems"
 
 export
-molInput : String -> Ref TextArea
-molInput pre = Id "\{pre}-mol-input"
+infoID : String -> Ref Div
+infoID pre = Id "\{pre}-draw-info"
 
-export
-leftBarID : String -> Ref Div
-leftBarID pre = Id "\{pre}-left-bar"
-
-export
 detailsID : String -> Ref Div
 detailsID pre = Id "\{pre}-draw-details"
 
-export
-rightBarID : String -> Ref Div
-rightBarID pre = Id "\{pre}-right-bar"
+utilsID : String -> Ref Div
+utilsID pre = Id "\{pre}-utils"
 
-export
-topBarID : String -> Ref Div
-topBarID pre = Id "\{pre}-top-bar"
-
-export
-bottomBarID : String -> Ref Div
-bottomBarID pre = Id "\{pre}-bottom-bar"
+templatesID : String -> Ref Div
+templatesID pre = Id "\{pre}-templates"
 
 export
 expButton : String -> Ref Tag.Button
@@ -207,7 +193,7 @@ pse (SetAtom i) = all (i.elem /=) (the (List Elem) [C,O,N,F,P,S,Cl,Br])
 pse _           = False
 
 detail : String -> HTMLNode -> HTMLNode
-detail ttl n = div [class formRow] [label [class formLabel] [Text ttl], n]
+detail ttl n = div [class listEntry] [label [] [Text ttl], n]
 
 currAbbr : Mode -> Maybe String
 currAbbr (SetAbbr a) = Just a.label
@@ -215,15 +201,15 @@ currAbbr _           = Nothing
 
 parameters {auto de : Sink DrawEvent}
 
-  elems : MolAtomAT -> HTMLNode
-  elems a =
+  elements : MolAtomAT -> HTMLNode
+  elements a =
     selectFromListBy values (a.elem.elem ==) symbol ChgElem
-      [ classes [widget,formValue], title "set element" ]
+      [class widget, title "set element"]
 
   charges : MolAtomAT -> HTMLNode
   charges a =
     selectFromListBy chs (a.charge ==) (show . value) ChgCharge
-      [ classes [widget,formValue], title "set charge" ]
+      [class widget, title "set charge"]
     where
       chs : List Charge
       chs = mapMaybe refineCharge [(-8) .. 8]
@@ -231,12 +217,12 @@ parameters {auto de : Sink DrawEvent}
   massNrs : MolAtomAT -> HTMLNode
   massNrs a =
     selectFromListBy (masses a.elem.elem) (a.elem.mass ==) dispMass ChgMass
-      [ classes [widget,formValue], title "set charge" ]
+      [class widget, title "set charge"]
     where
       dispMass : Maybe MassNr -> String
       dispMass Nothing  = "Mix"
       dispMass (Just m) = show m.value
-  
+
   icon :
        Classes
     -> DrawEvent
@@ -246,7 +232,7 @@ parameters {auto de : Sink DrawEvent}
     -> HTMLNode
   icon cs ev a ttl child =
     button
-      [classes (widget::icon::quadratic::cs),active a,onClick ev,title ttl]
+      [classes (widget::icon::cs),active a,onClick ev,title ttl]
       [child]
 
   abbrs : (ds : DrawSettings) => (pre : String) -> DrawState -> HTMLNode
@@ -261,15 +247,15 @@ parameters {auto de : Sink DrawEvent}
   bondIcon : MolBond -> String -> DrawState -> HTMLNode -> HTMLNode
   bondIcon b title s = icon [] (SetBond b) (drawing b s) title
 
-  topBar :
+  utils :
        {auto ds : DrawSettings}
     -> (pre     : String)
     -> (topadd  : HTMLNodes)
     -> DrawState
     -> HTMLNode
-  topBar {ds} pre topadd s =
+  utils {ds} pre topadd s =
     div
-      [ Id $ topBarID pre, class toolbarTop ] $
+      [ Id $ utilsID pre, class drawUtils ] $
       [ icon [] SelectMode (s.mode == Select) "select" select
       , icon [] EraseMode (s.mode == Erase) "erase" erase
       , icon [] Clear False "clear" trash
@@ -296,9 +282,9 @@ parameters {auto de : Sink DrawEvent}
   elemIcon : DrawState -> String -> Elem -> HTMLNode
   elemIcon s t e = icon [elemText e] (SetElem e) (setting e s) t (Text $ symbol e)
 
-  leftBar pre s =
+  elems pre s =
     div
-      [ Id $ leftBarID pre, class toolbarLeft ]
+      [ Id $ elemsID pre, class drawElems ]
       [ elemIcon s "Boron" B
       , elemIcon s "Carbon" C
       , elemIcon s "Oxygen" O
@@ -321,12 +307,12 @@ parameters {auto de : Sink DrawEvent}
             [x,y,_] := atm.position
             cx      := dispCoordShort x
             cy      := dispCoordShort y
-         in [ detail "Element"  $ elems atm, formSep
+         in [ detail "Element"  $ elements atm, formSep
             , detail "Isotope"  $ massNrs atm, formSep
             , detail "Charge"   $ charges atm, formSep
-            , detail "Type"     $ div [class formValue] [Text tpe], formSep
-            , detail "x-Coord." $ div [class formValue] [Text cx], formSep
-            , detail "y-Coord." $ div [class formValue] [Text cy]
+            , detail "Type"     $ div [class listEntryValue] [Text tpe], formSep
+            , detail "x-Coord." $ div [class listEntryValue] [Text cx], formSep
+            , detail "y-Coord." $ div [class listEntryValue] [Text cy]
             ]
       _   => case selectedEdges s.imol of
         [(x,y)] =>
@@ -335,8 +321,8 @@ parameters {auto de : Sink DrawEvent}
               d  := printDouble 3 $ distance px py
               a  := angleOrZero (px - py)
               a' := printDouble (S Z) $ toDegree $ if a >= Angle.pi then (a - Angle.pi) else a
-           in [ detail "Length"   $ div [class formValue] [Text "\{d} Å"], formSep
-              , detail "Angle"    $ div [class formValue] [Text "\{a'}°"]
+           in [ detail "Length"   $ div [class listEntryValue] [Text "\{d} Å"], formSep
+              , detail "Angle"    $ div [class listEntryValue] [Text "\{a'}°"]
               ]
         _       => []
 
@@ -344,14 +330,14 @@ parameters {auto de : Sink DrawEvent}
   details pre s =
     div
       [ Id $ detailsID pre, class drawDetails ]
-      [ div [class compTitle] ["Details"]
-      , div [class compList] (detailItems pre s)
+      [ h1 [] ["Details"]
+      , ul [] (detailItems pre s)
       ]
 
-  bottomBar : DrawSettings => (pre : String) -> DrawState -> HTMLNode
-  bottomBar pre s =
+  templates : DrawSettings => (pre : String) -> DrawState -> HTMLNode
+  templates pre s =
     div
-      [ Id $ bottomBarID pre, class toolbarBottom ]
+      [ Id $ templatesID pre, class drawTemplates ]
       [ template phenyl "benzene" s benzene
       , template (ring 6) "cyclohexane" s cyclohexane
       , template (ring 5) "cyclopentane" s cyclopentane
@@ -372,10 +358,10 @@ parameters {auto de : Sink DrawEvent}
     -> HTMLNode
   sketcher pre topadd s =
     div
-      [ class sketcherDiv, Id $ sketcherDiv pre ]
-      [ topBar pre topadd s
-      , leftBar pre s
-      , div [Id $ rightBarID pre, class toolbarRight] [details pre s]
+      [ class sketcher, Id $ sketcherDiv pre ]
+      [ utils pre topadd s
+      , elems pre s
+      , div [class drawInfo, Id $ infoID pre] [details pre s]
       , div
           [ class moleculeCanvas
           , Id $ moleculeCanvas pre
@@ -393,7 +379,7 @@ parameters {auto de : Sink DrawEvent}
           , active s.isActive
           ]
           [Raw s.curSVG]
-      , bottomBar pre s
+      , templates pre s
       ]
 
 export
@@ -445,9 +431,9 @@ parameters {auto ds : DrawSettings}
   adjustBars : DrawState -> Act ()
   adjustBars s = Prelude.do
     topadd <- ex.buttons (DE pre) s
-    replace (topBarID pre) (topBar pre topadd s)
-    replace (bottomBarID pre) (bottomBar pre s)
-    replace (leftBarID pre) (leftBar pre s)
+    replace (utilsID pre) (utils pre topadd s)
+    replace (templatesID pre) (templates pre s)
+    replace (elemsID pre) (elems pre s)
     replace (detailsID pre) (details pre s)
 
   dispKeyDown : String -> DrawState -> Act ()


### PR DESCRIPTION
I read quite a bit about semantics and DRY in CSS. Of course, we did it all wrong, that's why my CSS rules in CyBy are a complete mess.

We can do better by using fewer (but semantic!) classes and fine grained selectors. Code reuse (and type safety!) comes from Idris.