### PR TITLE
[ css ] cursor state

### DIFF
--- a/cyby-css/src/CyBy/UI/CSS/Classes.idr
+++ b/cyby-css/src/CyBy/UI/CSS/Classes.idr
@@ -1,16 +1,27 @@
 module CyBy.UI.CSS.Classes
 
 import Chem.Elem
+import Derive.Prelude
 import Data.String
 import IO.Async.Logging
 import Text.HTML.Attribute
 import public Text.CSS.Class
 
 %default total
+%language ElabReflection
 
 --------------------------------------------------------------------------------
 -- Attributes
 --------------------------------------------------------------------------------
+
+public export
+data DragMode = None | Rotating | Dragging
+
+%runElab derive "DragMode" [Show,Eq]
+
+export %inline
+dragMode : DragMode -> Attribute t
+dragMode = Str "data-dragmode" . toLower . show
 
 export %inline
 active : Bool -> Attribute t
@@ -63,14 +74,6 @@ drawLog = "cyby-draw-log"
 export %inline
 moleculeCanvas : Class
 moleculeCanvas = "cyby-draw-molecule-canvas"
-
-export %inline
-rotating : Class
-rotating = "cyby-draw-rotating"
-
-export %inline
-dragging : Class
-dragging = "cyby-draw-dragging"
 
 export %inline
 listEntry : Class

--- a/cyby-css/src/CyBy/UI/CSS/Rules.idr
+++ b/cyby-css/src/CyBy/UI/CSS/Rules.idr
@@ -18,9 +18,15 @@ data Tag = Util | Templates | Elems | Info | Draw | Dot
 %runElab derive "Tag" [Show,Eq]
 
 export
-set : ({0 k : Type} -> {0 t : k} ->  Bool -> Attribute t) -> Selector 
-set f =
-  case f {t = ()} True of
+attr : Attribute () -> Selector 
+attr (Str  n v) = Attr n $ Equals v
+attr (Bool n _) = Attr n Set
+attr _          = []
+
+export
+boolAttr : (Bool -> Attribute ()) -> Selector 
+boolAttr f =
+  case f True of
     Bool name _ => Attr name Set
     _           => Attr "" Set
 
@@ -157,7 +163,7 @@ parameters {auto v : Vars}
     [ sel s $ alignSelf Stretch :: hpadded :: wregular
     , sel [s, Hover] whovered
     , sel [s, Active] wactive
-    , sel [s, set active] wactive
+    , sel [s, boolAttr active] wactive
     , sel [s, Disabled] wdisabled
     ]
 
@@ -216,10 +222,10 @@ parameters {auto v : Vars}
         :: drawCompBorder
 
     -- drawing canvas: special states
-    , sel [class moleculeCanvas, set active]
+    , sel [class moleculeCanvas, boolAttr active]
         [backgroundColor white, outlineWidth v.fatBW, outlineColor activeFG]
-    , classes [moleculeCanvas,dragging] [cursor [Move]]
-    , classes [moleculeCanvas,rotating]
+    , sel (attr $ dragMode Dragging) [cursor [Move]]
+    , sel (attr $ dragMode Rotating)
         [cursor [URL_ "data:image/png;base64,\{rotate}", Cursor.Auto]]
 
     -- CyBy Draw toolbars

--- a/src/CyBy/Draw.idr
+++ b/src/CyBy/Draw.idr
@@ -400,26 +400,14 @@ parameters {auto ds : DrawSettings}
            {auto ex : Extension}
            (pre : String)
 
-  canvasCls : List Class -> Act ()
-  canvasCls = attr (moleculeCanvas pre) . classes . (moleculeCanvas ::)
-
-  rotating : Act ()
-  rotating = canvasCls [rotating]
-
-  dragging : Act ()
-  dragging = canvasCls [dragging]
-
-  normal : Act ()
-  normal = canvasCls []
-
   selectCursor : DrawState -> Act ()
   selectCursor s =
-    case s.mode of
-      Dragging _    => dragging
-      Rotating _    => rotating
-      RotTempl _ _  => rotating
-      Translating _ => dragging
-      _             => applyWhenSel s dragging rotating normal
+    attr (moleculeCanvas pre) $ dragMode $ case s.mode of
+      Dragging _    => Dragging
+      Rotating _    => Rotating
+      RotTempl _ _  => Rotating
+      Translating _ => Dragging
+      _             => applyWhenSel s Dragging Rotating None
 
   displayST : (force : Bool) -> DrawState -> Act ()
   displayST force s = Prelude.do


### PR DESCRIPTION
This uses a `data-` attribute instead of a class to keep track of the draw cursor in the CSS rules. This feels more natural: HTML elements and classes for semantics, attributes and pseudo-classes for state.