### PR TITLE
[ css ] absolute positioning of sketcher

### DIFF
--- a/cyby-css/src/CyBy/UI/CSS/Rules.idr
+++ b/cyby-css/src/CyBy/UI/CSS/Rules.idr
@@ -162,7 +162,7 @@ parameters {auto v : Vars}
         , width 100.perc
         , backgroundColor bg
         , color fg
-        , padding (All v.largePadding)
+        , padded
         , containerType Size
         ]
 
@@ -188,8 +188,15 @@ parameters {auto v : Vars}
           , [Elems, Draw,      Info     ]
           , [Dot,   Templates, Templates]
           ]
-        :: width 100.perc
-        :: height 100.perc
+
+        -- make sure the sketcher always fills the parent perfectly
+        -- without resizing the parent in case the sketcher's size
+        -- changes.
+        :: position Absolute
+        :: inset (All 0.px)
+
+        -- scroll bars in case the parent is too small
+        :: overflow Auto
         :: gridGaps
 
     -- the following rules make for a responsive design:
@@ -279,5 +286,8 @@ parameters {auto v : Vars}
   all : Rules
   all = general ++ components ++ forms ++ widgets
 
+  draw : Rules
+  draw = class sketcher [padded] :: all
+
 main : IO ()
-main = traverse_ (putStrLn . interpolate) (all @{defaultVars})
+main = traverse_ (putStrLn . interpolate) (draw @{defaultVars})


### PR DESCRIPTION
Time and again, we saw occasional and hard to reproduce auto-resizing of molecule sketchers. The reason was always the same though: A change to the size of the sketcher (for whatever reason) led to a change of the size of the parent, which led to a `Resize` effect being fired and another change to the size of the sketcher, and so on, ad infinitum.

Seems like there is a solution for this: By using an *absolute* positioning of the sketcher (CSS: `position: absolute`), any changes to the dimensions of the sketchers are completely decoupled from and no longer affect its container.

Do I trust this? No. But it makes me sound smart, so I give it a try.